### PR TITLE
feat: remove usage while in different states

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -65,12 +65,12 @@ local keybind = lib.addKeybind({
 })
 local scaleform = nil
 lib.callback.register('qbx_binoculars:client:toggle', function()
-    if cache.vehicle then return end
+    if cache.vehicle or QBX.PlayerData.metadata.isdead or QBX.PlayerData.metadata.ishandcuffed or QBX.PlayerData.metadata.inlaststand then return end
     binoculars = not binoculars
 
     if binoculars then
         TaskStartScenarioInPlace(cache.ped, 'WORLD_HUMAN_BINOCULARS', 0, true)
-        cam = CreateCam('DEFAULT_SCRIPTED_CAMERA', true)
+        cam = CreateCam('DEFAULT_SCRIPTED_FLY_CAMERA', true)
         AttachCamToEntity(cam, cache.ped, 0.0, 0.2, 0.7, true)
         SetCamRot(cam, 0.0, 0.0, GetEntityHeading(cache.ped), 2)
         RenderScriptCams(true, false, 5000, true, false)
@@ -90,7 +90,7 @@ lib.callback.register('qbx_binoculars:client:toggle', function()
             BeginScaleformMovieMethod(scaleform, 'SET_CAM_LOGO')
             ScaleformMovieMethodAddParamInt(0)
             EndScaleformMovieMethod()
-    
+
             local zoomValue = (1.0 / (MAX_FOV - MIN_FOV)) * (fov - MIN_FOV)
             checkInputRotation(cam, zoomValue)
             handleZoom(cam)

--- a/client/main.lua
+++ b/client/main.lua
@@ -57,13 +57,15 @@ local keybind = lib.addKeybind({
     onPressed = function()
         binoculars = false
         ClearPedTasks(cache.ped)
+        RenderScriptCams(false, true, 500, false, false)
+        SetScaleformMovieAsNoLongerNeeded(scaleform)
         DestroyCam(cam, false)
         cam = nil
     end,
 })
-local scaleform = nil
+local scaleform
 lib.callback.register('qbx_binoculars:client:toggle', function()
-    if cache.vehicle or or IsPedSwimming(cache.ped) or QBX.PlayerData.metadata.isdead or QBX.PlayerData.metadata.ishandcuffed or QBX.PlayerData.metadata.inlaststand then return end
+    if cache.vehicle or IsPedSwimming(cache.ped) or QBX.PlayerData.metadata.isdead or QBX.PlayerData.metadata.ishandcuffed or QBX.PlayerData.metadata.inlaststand then return end
     binoculars = not binoculars
 
     if binoculars then
@@ -71,12 +73,12 @@ lib.callback.register('qbx_binoculars:client:toggle', function()
         cam = CreateCam('DEFAULT_SCRIPTED_FLY_CAMERA', true)
         AttachCamToEntity(cam, cache.ped, 0.0, 0.2, 0.7, true)
         SetCamRot(cam, 0.0, 0.0, GetEntityHeading(cache.ped), 2)
-        RenderScriptCams(true, false, 5000, true, false)
+        RenderScriptCams(true, false, 500, true, false)
         keybind:disable(false)
     else
         ClearPedTasks(cache.ped)
-        RenderScriptCams(false, true, 1000, false, false)
-        SetScaleformMovieAsNoLongerNeeded()
+        RenderScriptCams(false, true, 500, false, false)
+        SetScaleformMovieAsNoLongerNeeded(scaleform)
         DestroyCam(cam, false)
         cam = nil
         keybind:disable(true)

--- a/client/main.lua
+++ b/client/main.lua
@@ -57,8 +57,6 @@ local keybind = lib.addKeybind({
     onPressed = function()
         binoculars = false
         ClearPedTasks(cache.ped)
-        RenderScriptCams(false, true, 1000, false, false)
-        SetScaleformMovieAsNoLongerNeeded()
         DestroyCam(cam, false)
         cam = nil
     end,

--- a/client/main.lua
+++ b/client/main.lua
@@ -65,7 +65,7 @@ local keybind = lib.addKeybind({
 })
 local scaleform = nil
 lib.callback.register('qbx_binoculars:client:toggle', function()
-    if cache.vehicle or QBX.PlayerData.metadata.isdead or QBX.PlayerData.metadata.ishandcuffed or QBX.PlayerData.metadata.inlaststand then return end
+    if cache.vehicle or or IsPedSwimming(cache.ped) or QBX.PlayerData.metadata.isdead or QBX.PlayerData.metadata.ishandcuffed or QBX.PlayerData.metadata.inlaststand then return end
     binoculars = not binoculars
 
     if binoculars then

--- a/client/main.lua
+++ b/client/main.lua
@@ -50,6 +50,7 @@ local function hideHUDThisFrame()
 end
 
 local cam = nil
+local scaleform
 local keybind = lib.addKeybind({
     name = 'closeBinoculars',
     description = 'Close Binoculars',
@@ -63,7 +64,6 @@ local keybind = lib.addKeybind({
         cam = nil
     end,
 })
-local scaleform
 lib.callback.register('qbx_binoculars:client:toggle', function()
     if cache.vehicle or IsPedSwimming(cache.ped) or QBX.PlayerData.metadata.isdead or QBX.PlayerData.metadata.ishandcuffed or QBX.PlayerData.metadata.inlaststand then return end
     binoculars = not binoculars

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -10,7 +10,10 @@ shared_scripts {
 	'@qbx_core/modules/utils.lua',
 }
 
-client_script 'client/main.lua'
+client_scripts {
+	'@qbx_core/modules/playerdata.lua',
+    'client/main.lua'
+}
 
 server_script 'server/main.lua'
 


### PR DESCRIPTION
## Description

- Stops the usage of the binoculars while swimming, in laststand, dead, or handcuffed
- Adds the PlayerData module
- Adjusts the camera and its timing
- Adds the scaleform variable to natives properly

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
