### PR TITLE
fix(scaleform): fix overlay not rendering over 100% of the screen

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -95,7 +95,7 @@ lib.callback.register('qbx_binoculars:client:toggle', function()
             checkInputRotation(cam, zoomValue)
             handleZoom(cam)
             hideHUDThisFrame()
-            DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
+            DrawScaleformMovie(scaleform, 0.5, 0.5, 1.0, 1.0, 255, 255, 255, 255)
             Wait(0)
         end
     end)


### PR DESCRIPTION
Tested at 1920x1080 and 2560x1440 resolutions.

## Description

This fixes a small issue in regards to the scaleform rending. There's a small sliver (test on 2K resolution) that you can see through when using the fullscreen variant of the draw scaleform native, This fixes that. 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
