### PR TITLE
fix(client): fix close bind clearing ped tasks (running) when binoculars are not active

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -56,6 +56,7 @@ local keybind = lib.addKeybind({
     description = 'Close Binoculars',
     defaultKey = 'BACK',
     onPressed = function()
+        if not binoculars then return end
         binoculars = false
         ClearPedTasks(cache.ped)
         RenderScriptCams(false, true, 500, false, false)


### PR DESCRIPTION
## Description

This stops the close binoculars code from running when they're not active. Backspace (the default bind) is commonly used in menus as the close button, so with emote menus specifically it's an issue since when you close the menu, it also stops the emote.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
