### PR TITLE
fix: replace callback with regular event

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -71,7 +71,7 @@ local keybind = lib.addKeybind({
     end,
 })
 
-lib.callback.register('qbx_binoculars:client:toggle', function()
+RegisterNetEvent('qbx_binoculars:client:toggle', function()
     if cache.vehicle or IsPedSwimming(cache.ped) or QBX.PlayerData.metadata.isdead or QBX.PlayerData.metadata.ishandcuffed or QBX.PlayerData.metadata.inlaststand then return end
     binoculars = not binoculars
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,5 +1,5 @@
 lib.versionCheck('Qbox-project/qbx_binoculars')
 
 exports.qbx_core:CreateUseableItem('binoculars', function(source)
-    lib.callback('qbx_binoculars:client:toggle', source)
+    TriggerClientEvent('qbx_binoculars:client:toggle', source)
 end)


### PR DESCRIPTION
## Description

The following warning is triggered when using the binoculars :
```
[script:qbx_binocular] Warning: callback event 'qbx_binoculars:client:toggle' does not have a function to callback to and will instead await
[script:qbx_binocular] use lib.callback.await or a regular event to remove this warning
```

This PR replaces the callback with a regular event, as no callback value is returned nor needed.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
