### PR TITLE
Fix camera craziness on closing binos

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -53,8 +53,10 @@ local cam = nil
 local scaleform
 
 local function closeBinoculars()
+    ClearTimecycleModifier()
+    fov = (MAX_FOV + MIN_FOV) * 0.5
     ClearPedTasks(cache.ped)
-    RenderScriptCams(false, true, 500, false, false)
+    RenderScriptCams(false, false, 500, true, false)
     SetScaleformMovieAsNoLongerNeeded(scaleform)
     DestroyCam(cam, false)
     cam = nil


### PR DESCRIPTION
## Description

Camera view no longer freaks out when closing binoculars. View closes and you see player lower binos and put them away now.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
